### PR TITLE
Revert "Using enums"

### DIFF
--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/BlackOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/BlackOilFlash.cpp
@@ -25,10 +25,9 @@ bool BlackOilFlash::ComputeEquilibrium(MultiphaseSystemProperties& out_variables
   const auto& pressure = out_variables.Pressure;
 
   // Component index are 0=OIL, 1=GAS, 2=WATER
-  auto& zo = out_variables.Feed[static_cast<size_t>(PHASE_TYPE::OIL)];
-//  auto& zo = out_variables.Feed[0];
-  auto& zg = out_variables.Feed[static_cast<size_t>(PHASE_TYPE::GAS)];
-  auto& zw = out_variables.Feed[static_cast<size_t>(PHASE_TYPE::LIQUID_WATER_RICH)];
+  auto& zo = out_variables.Feed[0];
+  auto& zg = out_variables.Feed[1];
+  auto& zw = out_variables.Feed[2];
 
   const auto& oil_phase_model = std::dynamic_pointer_cast<BlackOil_OilModel>(out_variables.PhaseModels.at(PHASE_TYPE::OIL));
   const auto& gas_phase_model = std::dynamic_pointer_cast<BlackOil_GasModel>(out_variables.PhaseModels.at(PHASE_TYPE::GAS));
@@ -187,3 +186,5 @@ bool BlackOilFlash::ComputeEquilibrium(MultiphaseSystemProperties& out_variables
 }
 
 }
+
+


### PR DESCRIPTION
Some indices consistency needs to be done carefully.
This reverts commit b239ac5b
See comments https://github.com/GEOSX/PVTPackage/commit/b239ac5beadc1e40394b7f332d888edb47c602c1#r39869430