### PR TITLE
Implemented two-phase DO model

### DIFF
--- a/PVTPackage/source/MultiphaseSystem/BlackOilMultiphaseSystem.cpp
+++ b/PVTPackage/source/MultiphaseSystem/BlackOilMultiphaseSystem.cpp
@@ -33,7 +33,7 @@ BlackOilMultiphaseSystem::BlackOilMultiphaseSystem( const std::vector< pvt::PHAS
   m_blackOilFlash( PVTO, oilSurfaceMassDensity, oilSurfaceMolecularWeight,
                    PVTG, gasSurfaceMassDensity, gasSurfaceMolecularWeight,
                    PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight ),
-  m_bofmsp( phases.size() )
+  m_bofmsp( phases )
 {
 
 }

--- a/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.cpp
+++ b/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.cpp
@@ -96,13 +96,6 @@ std::unique_ptr< DeadOilMultiphaseSystem > DeadOilMultiphaseSystem::build( const
   const bool containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.cend();
   const bool containsWater = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::LIQUID_WATER_RICH ) != phases.cend();  
 
-  const bool isValid = containsOil && ( containsGas || containsWater );
-  if( !isValid )  
-  {    
-    const std::string msg = "Three types of DO systems are allowed: Oil-Water-Gas, Oil-Water, and Oil-Gas";
-    LOGERROR( msg );
-  }
-   
   // props.oilTable, props.gasTable and props.waterTable respectively contain PVDO, PVDG and PVTW
   const Properties & props = buildTables( phases, tableFileNames, surfaceDensities, molarWeights );
 
@@ -122,12 +115,18 @@ std::unique_ptr< DeadOilMultiphaseSystem > DeadOilMultiphaseSystem::build( const
                                               props.gasTable, props.gasSurfaceMassDensity, props.gasSurfaceMolecularWeight );
     return std::unique_ptr< DeadOilMultiphaseSystem >( ptr );
   }
-  else // containsOil && containsWater
+  else if( containsOil && containsWater )
   {
     auto * ptr = new DeadOilMultiphaseSystem( phases,
                                               props.oilTable, props.oilSurfaceMassDensity, props.oilSurfaceMolecularWeight,
                                               props.waterTable, props.waterSurfaceMassDensity, props.waterSurfaceMolecularWeight );
     return std::unique_ptr< DeadOilMultiphaseSystem >( ptr );    
+  }
+  else
+  {
+    // FIXME: add a pvt::PHASE_TYPE -> string converter to log the provided phases
+    const std::string msg = "Three types of DO systems are allowed: Oil-Water-Gas, Oil-Water, and Oil-Gas";
+    LOGERROR( msg );
   }
 }
 

--- a/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.cpp
+++ b/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.cpp
@@ -16,6 +16,8 @@
 
 #include "pvt/pvt.hpp"
 
+#include <algorithm>
+
 namespace PVTPackage
 {
 
@@ -33,7 +35,7 @@ DeadOilMultiphaseSystem::DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_
   m_deadOilFlash( PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight,
                   PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight,
                   PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight ),
-  m_dofmsp( phases.size() )
+  m_dofmsp( phases )
 {
 
 }
@@ -62,6 +64,16 @@ std::unique_ptr< DeadOilMultiphaseSystem > DeadOilMultiphaseSystem::build( const
                                                                            const std::vector< double > & surfaceDensities,
                                                                            const std::vector< double > & molarWeights )
 {
+  const bool containsOil = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::OIL ) != phases.end();
+  const bool containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.end();
+  const bool containsWater = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::LIQUID_WATER_RICH ) != phases.end();  
+
+  if( !( (containsOil && containsGas) || (containsOil && containsWater) ) )
+  {    
+    const std::string msg = "Three types of DO systems are allowed: Oil-Water-Gas, Oil-Water, and Oil-Gas";
+    LOGERROR( msg );
+  }
+   
   // props.oilTable, props.gasTable and props.waterTable respectively contain PVDO, PVDG and PVTW
   const Properties & props = buildTables( phases, tableFileNames, surfaceDensities, molarWeights );
 

--- a/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.hpp
+++ b/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.hpp
@@ -40,6 +40,7 @@ public:
 
 private:
 
+  // Three-phase dead-oil 
   DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_TYPE > & phases,
                            const std::vector< std::vector< double > > & PVDO,
                            double oilSurfaceMassDensity,
@@ -51,6 +52,25 @@ private:
                            double waterSurfaceMassDensity,
                            double waterSurfaceMolecularWeight );
 
+  // Two-phase oil-gas dead-oil
+  DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_TYPE > & phases,
+                           const std::vector< std::vector< double > > & PVDO,
+                           double oilSurfaceMassDensity,
+                           double oilSurfaceMolecularWeight,
+                           const std::vector< std::vector< double > > & PVDG,
+                           double gasSurfaceMassDensity,
+                           double gasSurfaceMolecularWeight );
+
+  // Two-phase oil-water dead-oil
+  DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_TYPE > & phases,
+                           const std::vector< std::vector< double > > & PVDO,
+                           double oilSurfaceMassDensity,
+                           double oilSurfaceMolecularWeight,
+                           const std::vector< double > & PVTW,
+                           double waterSurfaceMassDensity,
+                           double waterSurfaceMolecularWeight );
+  
+  
   DeadOilFlash m_deadOilFlash;
 
   DeadOilFlashMultiphaseSystemProperties m_dofmsp;

--- a/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.hpp
+++ b/PVTPackage/source/MultiphaseSystem/DeadOilMultiphaseSystem.hpp
@@ -40,7 +40,9 @@ public:
 
 private:
 
-  // Three-phase dead-oil 
+  /**
+   * @brief Constructor for the three-phase Dead-Oil system
+   */
   DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_TYPE > & phases,
                            const std::vector< std::vector< double > > & PVDO,
                            double oilSurfaceMassDensity,
@@ -52,7 +54,9 @@ private:
                            double waterSurfaceMassDensity,
                            double waterSurfaceMolecularWeight );
 
-  // Two-phase oil-gas dead-oil
+  /**
+   * @brief Constructor for the two-phase oil-gas Dead-Oil system
+   */
   DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_TYPE > & phases,
                            const std::vector< std::vector< double > > & PVDO,
                            double oilSurfaceMassDensity,
@@ -61,7 +65,9 @@ private:
                            double gasSurfaceMassDensity,
                            double gasSurfaceMolecularWeight );
 
-  // Two-phase oil-water dead-oil
+  /**
+   * @brief Constructor for the two-phase oil-water Dead-Oil system
+   */
   DeadOilMultiphaseSystem( const std::vector< pvt::PHASE_TYPE > & phases,
                            const std::vector< std::vector< double > > & PVDO,
                            double oilSurfaceMassDensity,

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystem.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystem.cpp
@@ -32,6 +32,7 @@ struct FiniteDifferenceDerivatives
   double dMolecularWeight;
   double dMoleDensity;
   double dMassDensity;
+  double dViscosity;
   std::vector< double > dMoleComposition;
 };
 
@@ -57,6 +58,7 @@ FiniteDifferenceDerivatives updateDerivativeFiniteDifference( const pvt::PHASE_T
   result.dMolecularWeight = ( variation.getMolecularWeight( phase ).value - reference.getMolecularWeight( phase ).value ) / delta;
   result.dMoleDensity = ( variation.getMoleDensity( phase ).value - reference.getMoleDensity( phase ).value ) / delta;
   result.dMassDensity = ( variation.getMassDensity( phase ).value - reference.getMassDensity( phase ).value ) / delta;
+  result.dViscosity = ( variation.getViscosity( phase ).value - reference.getViscosity( phase ).value ) / delta;  
 
   const std::vector< double > & refMoleComposition = reference.getMoleComposition( phase ).value;
   const std::vector< double > & varMoleComposition = variation.getMoleComposition( phase ).value;
@@ -81,6 +83,7 @@ void MultiphaseSystem::updateDerivativeDPFiniteDifference( FactorMultiphaseSyste
     sysProps.setMolecularWeightDP( phase, values.dMolecularWeight );
     sysProps.setMoleDensityDP( phase, values.dMoleDensity );
     sysProps.setMassDensityDP( phase, values.dMassDensity );
+    sysProps.setViscosityDP( phase, values.dViscosity );
     sysProps.setMoleCompositionDP( phase, values.dMoleComposition );
   }
 }
@@ -98,6 +101,7 @@ void MultiphaseSystem::updateDerivativeDZFiniteDifference( std::size_t iComponen
     sysProps.setMolecularWeightDZ( phase, iComponent, values.dMolecularWeight );
     sysProps.setMoleDensityDZ( phase, iComponent, values.dMoleDensity );
     sysProps.setMassDensityDZ( phase, iComponent, values.dMassDensity );
+    sysProps.setViscosityDZ( phase, iComponent, values.dViscosity );
     sysProps.setMoleCompositionDZ( phase, iComponent, values.dMoleComposition );
   }
 }
@@ -138,13 +142,20 @@ TableReader::Properties TableReader::buildTables( const std::vector< pvt::PHASE_
   // Check if both oil and gas are defined
   const bool containsOil = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::OIL ) != phases.end();
   const bool containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.end();
-  ASSERT( containsOil and containsGas, "Both oil and gas phase must be defined for neither DeadOil nor BlackOil model" );
+  ASSERT( containsOil or containsGas, "Both oil and gas phase must be defined for neither DeadOil nor BlackOil model" );
 
   // Reading data from files
   const std::vector< std::vector< std::vector< double > > > phaseTables = readTables( phases, tableFileNames );
 
   Properties result;
-
+  // initialize result, in case the water or gas tables are not provided (for the two-phase case)
+  result.oilSurfaceMassDensity       = 0.0;
+  result.oilSurfaceMolecularWeight   = 0.0;
+  result.gasSurfaceMassDensity       = 0.0;
+  result.gasSurfaceMolecularWeight   = 0.0;
+  result.waterSurfaceMassDensity     = 0.0;
+  result.waterSurfaceMolecularWeight = 0.0;
+  
   for( std::size_t i = 0; i != phases.size(); ++i )
   {
     pvt::PHASE_TYPE const & phase = phases[i];
@@ -204,6 +215,7 @@ void CompositionalMultiphaseSystem::updateDerivativeDTFiniteDifference( Composit
     sysProps.setMolecularWeightDT( phase, values.dMolecularWeight );
     sysProps.setMoleDensityDT( phase, values.dMoleDensity );
     sysProps.setMassDensityDT( phase, values.dMassDensity );
+    sysProps.setViscosityDT( phase, values.dViscosity );
     sysProps.setMoleCompositionDT( phase, values.dMoleComposition );
   }
 }

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystem.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystem.cpp
@@ -141,20 +141,12 @@ TableReader::Properties TableReader::buildTables( const std::vector< pvt::PHASE_
 {
   // Check if both oil and gas are defined
   const bool containsOil = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::OIL ) != phases.end();
-  const bool containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.end();
-  ASSERT( containsOil or containsGas, "Both oil and gas phase must be defined for neither DeadOil nor BlackOil model" );
+  ASSERT( containsOil, "The oil phase must be defined for all PVT models" );
 
   // Reading data from files
   const std::vector< std::vector< std::vector< double > > > phaseTables = readTables( phases, tableFileNames );
 
   Properties result;
-  // initialize result, in case the water or gas tables are not provided (for the two-phase case)
-  result.oilSurfaceMassDensity       = 0.0;
-  result.oilSurfaceMolecularWeight   = 0.0;
-  result.gasSurfaceMassDensity       = 0.0;
-  result.gasSurfaceMolecularWeight   = 0.0;
-  result.waterSurfaceMassDensity     = 0.0;
-  result.waterSurfaceMolecularWeight = 0.0;
   
   for( std::size_t i = 0; i != phases.size(); ++i )
   {

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.cpp
@@ -23,9 +23,9 @@
 namespace PVTPackage
 {
 
-BlackOilDeadOilMultiphaseSystemProperties::BlackOilDeadOilMultiphaseSystemProperties( std::size_t nComponents )
+BlackOilDeadOilMultiphaseSystemProperties::BlackOilDeadOilMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases )
   :
-  FactorMultiphaseSystemProperties( { pvt::PHASE_TYPE::OIL, pvt::PHASE_TYPE::GAS, pvt::PHASE_TYPE::LIQUID_WATER_RICH }, nComponents )
+  FactorMultiphaseSystemProperties( phases, phases.size() )
 {
 
 }
@@ -33,9 +33,9 @@ BlackOilDeadOilMultiphaseSystemProperties::BlackOilDeadOilMultiphaseSystemProper
 void BlackOilDeadOilMultiphaseSystemProperties::setModelProperties( pvt::PHASE_TYPE const & phase,
                                                                     BlackOilDeadOilProperties const & props )
 {
-  // FIXME Viscosity is never used so I do not store it.
   m_massDensity.at( phase ).value = props.massDensity;
   m_moleDensity.at( phase ).value = props.moleDensity;
+  m_viscosity.at( phase ).value = props.viscosity;
   m_molecularWeight.at( phase ).value = props.massDensity / props.moleDensity;
 }
 

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.cpp
@@ -1,15 +1,15 @@
-/*	
- * ------------------------------------------------------------------------------------------------------------	
- * SPDX-License-Identifier: LGPL-2.1-only	
- *	
- * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC	
- * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University	
- * Copyright (c) 2018-2020 Total, S.A	
- * Copyright (c) 2020-     GEOSX Contributors	
- * All right reserved	
- *	
- * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.	
- * ------------------------------------------------------------------------------------------------------------	
+/*      
+ * ------------------------------------------------------------------------------------------------------------ 
+ * SPDX-License-Identifier: LGPL-2.1-only       
+ *      
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC     
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University       
+ * Copyright (c) 2018-2020 Total, S.A   
+ * Copyright (c) 2020-     GEOSX Contributors   
+ * All right reserved   
+ *      
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.      
+ * ------------------------------------------------------------------------------------------------------------ 
  */
 
 #include "BlackOilDeadOilMultiphaseSystemProperties.hpp"
@@ -25,7 +25,7 @@ namespace PVTPackage
 
 BlackOilDeadOilMultiphaseSystemProperties::BlackOilDeadOilMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases )
   :
-  FactorMultiphaseSystemProperties( phases, phases.size() )
+  FactorMultiphaseSystemProperties( phases, phases.size() ) // for both Black-Oil and Dead-Oil, the number of components is equal to the number of phases, hence we use phases.size() to fill nComponents in FactorMultiphaseSystemProperties
 {
 
 }
@@ -54,4 +54,10 @@ void BlackOilDeadOilMultiphaseSystemProperties::setWaterModelProperties( BlackOi
   setModelProperties( pvt::PHASE_TYPE::LIQUID_WATER_RICH, props );
 }
 
+std::size_t BlackOilDeadOilMultiphaseSystemProperties::getNComponents() const
+{
+  // for Black-Oil and Dead-Oil the number of components is equal to the number of phases
+  return getPhases().size(); 
+}
+  
 }

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.hpp
@@ -27,7 +27,7 @@ class BlackOilDeadOilMultiphaseSystemProperties : public FactorMultiphaseSystemP
 {
 public:
 
-  explicit BlackOilDeadOilMultiphaseSystemProperties( std::size_t nComponents );
+  explicit BlackOilDeadOilMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases );
 
   void setOilModelProperties( BlackOilDeadOilProperties const & props );
 
@@ -42,9 +42,7 @@ private:
    * @param phase The phase for which we want to set properties.
    * @param properties The new values.
    *
-   * Mainly defines mass density, mole density and molecular weight.
-   *
-   * @note Viscosity may be provided, but it's not stored since it's never used.
+   * Mainly defines mass density, mole density, viscosity, and molecular weight.
    */
   void setModelProperties( pvt::PHASE_TYPE const & phase,
                            BlackOilDeadOilProperties const & props );

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.hpp
@@ -1,15 +1,15 @@
-/*	
- * ------------------------------------------------------------------------------------------------------------	
- * SPDX-License-Identifier: LGPL-2.1-only	
- *	
- * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC	
- * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University	
- * Copyright (c) 2018-2020 Total, S.A	
- * Copyright (c) 2020-     GEOSX Contributors	
- * All right reserved	
- *	
- * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.	
- * ------------------------------------------------------------------------------------------------------------	
+/*      
+ * ------------------------------------------------------------------------------------------------------------ 
+ * SPDX-License-Identifier: LGPL-2.1-only       
+ *      
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC     
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University       
+ * Copyright (c) 2018-2020 Total, S.A   
+ * Copyright (c) 2020-     GEOSX Contributors   
+ * All right reserved   
+ *      
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.      
+ * ------------------------------------------------------------------------------------------------------------ 
  */
 
 #ifndef PVTPACKAGE_BLACKOILDEADOILMULTIPHASESYSTEMPROPERTIES_HPP
@@ -35,6 +35,13 @@ public:
 
   void setWaterModelProperties( BlackOilDeadOilProperties const & props );
 
+protected:
+  
+  /**
+   * @brief Returns the number of components (here, it is equal to the number of phases) 
+   */  
+  std::size_t getNComponents() const;
+  
 private:
 
   /**

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
@@ -17,10 +17,12 @@
 namespace PVTPackage
 {
 
-BlackOilFlashMultiphaseSystemProperties::BlackOilFlashMultiphaseSystemProperties( std::size_t nComponents )
+BlackOilFlashMultiphaseSystemProperties::BlackOilFlashMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases )
   :
-  BlackOilDeadOilMultiphaseSystemProperties( nComponents )
+  BlackOilDeadOilMultiphaseSystemProperties( phases )
 {
+  size_t const nComponents = phases.size();
+  
   for( pvt::PHASE_TYPE pt: getPhases() )
   {
     m_lnFugacity.insert( { pt, pvt::VectorPropertyAndDerivatives< double >( nComponents, nComponents ) } );

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
@@ -21,7 +21,7 @@ BlackOilFlashMultiphaseSystemProperties::BlackOilFlashMultiphaseSystemProperties
   :
   BlackOilDeadOilMultiphaseSystemProperties( phases )
 {
-  size_t const nComponents = phases.size();
+  size_t const nComponents = getNComponents();
   
   for( pvt::PHASE_TYPE pt: getPhases() )
   {

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.hpp
@@ -28,7 +28,7 @@ class BlackOilFlashMultiphaseSystemProperties : public BlackOilDeadOilMultiphase
 {
 public:
 
-  BlackOilFlashMultiphaseSystemProperties( std::size_t nComponents );
+  BlackOilFlashMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases );
 
   void setOilFraction( double const & fraction );
 

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.cpp
@@ -1,15 +1,15 @@
-/*	
- * ------------------------------------------------------------------------------------------------------------	
- * SPDX-License-Identifier: LGPL-2.1-only	
- *	
- * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC	
- * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University	
- * Copyright (c) 2018-2020 Total, S.A	
- * Copyright (c) 2020-     GEOSX Contributors	
- * All right reserved	
- *	
- * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.	
- * ------------------------------------------------------------------------------------------------------------	
+/*      
+ * ------------------------------------------------------------------------------------------------------------ 
+ * SPDX-License-Identifier: LGPL-2.1-only       
+ *      
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC     
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University       
+ * Copyright (c) 2018-2020 Total, S.A   
+ * Copyright (c) 2020-     GEOSX Contributors   
+ * All right reserved   
+ *      
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.      
+ * ------------------------------------------------------------------------------------------------------------ 
  */
 
 #include "CompositionalMultiphaseSystemProperties.hpp"
@@ -99,7 +99,7 @@ void CompositionalMultiphaseSystemProperties::setMassDensityDT( pvt::PHASE_TYPE 
 }
 
 void CompositionalMultiphaseSystemProperties::setViscosityDT( pvt::PHASE_TYPE const & phase,
-							      double const & value )
+                                                              double const & value )
 {
   m_viscosity.at( phase ).dT = value;
 }

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.cpp
@@ -65,6 +65,7 @@ void CompositionalMultiphaseSystemProperties::setModelProperties( const pvt::PHA
 {
   m_massDensity.at( phase ).value = properties.massDensity;
   m_moleDensity.at( phase ).value = properties.moleDensity;
+  m_viscosity.at( phase ).value = properties.viscosity;
   m_molecularWeight.at( phase ).value = properties.molecularWeight;
   // FIXME not so sure that all models use those two following data.
   m_compressibilityFactor.at( phase ) = properties.compressibilityFactor;
@@ -95,6 +96,12 @@ void CompositionalMultiphaseSystemProperties::setMassDensityDT( pvt::PHASE_TYPE 
                                                                 double const & value )
 {
   m_massDensity.at( phase ).dT = value;
+}
+
+void CompositionalMultiphaseSystemProperties::setViscosityDT( pvt::PHASE_TYPE const & phase,
+							      double const & value )
+{
+  m_viscosity.at( phase ).dT = value;
 }
 
 void CompositionalMultiphaseSystemProperties::setMoleCompositionDT( pvt::PHASE_TYPE const & phase,

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.hpp
@@ -69,6 +69,9 @@ public:
   void setMassDensityDT( pvt::PHASE_TYPE const & phase,
                          double const & value );
 
+  void setViscosityDT( pvt::PHASE_TYPE const & phase,
+		       double const & value );
+
   void setMoleCompositionDT( pvt::PHASE_TYPE const & phase,
                              std::vector< double > const & value );
 

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/CompositionalMultiphaseSystemProperties.hpp
@@ -70,7 +70,7 @@ public:
                          double const & value );
 
   void setViscosityDT( pvt::PHASE_TYPE const & phase,
-		       double const & value );
+                       double const & value );
 
   void setMoleCompositionDT( pvt::PHASE_TYPE const & phase,
                              std::vector< double > const & value );

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.cpp
@@ -17,26 +17,55 @@
 #include "pvt/pvt.hpp"
 
 #include <cmath>
+#include <algorithm>
 
 namespace PVTPackage
 {
 
-DeadOilFlashMultiphaseSystemProperties::DeadOilFlashMultiphaseSystemProperties( std::size_t nComponents )
+DeadOilFlashMultiphaseSystemProperties::DeadOilFlashMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases )
   :
-  BlackOilDeadOilMultiphaseSystemProperties( nComponents )
+  BlackOilDeadOilMultiphaseSystemProperties( phases )
 {
+  size_t const nComponents = phases.size();
+  
   for( pvt::PHASE_TYPE pt: getPhases() )
   {
     m_lnFugacity.insert( { pt, pvt::VectorPropertyAndDerivatives< double >( nComponents, nComponents ) } );
   }
 
-  m_moleComposition.at( pvt::PHASE_TYPE::OIL ).value = { 1., 0., 0. };
-  m_moleComposition.at( pvt::PHASE_TYPE::GAS ).value = { 0., 1., 0. };
-  m_moleComposition.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { 0., 0., 1. };
+  size_t const nPhases = phases.size();
 
-  m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
-  m_lnFugacity.at( pvt::PHASE_TYPE::GAS ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
-  m_lnFugacity.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+  // TODO: ultimately, all these if statements should go away
+  
+  if( nPhases == 3 )
+  {
+    m_moleComposition.at( pvt::PHASE_TYPE::OIL ).value = { 1., 0., 0. };
+    m_moleComposition.at( pvt::PHASE_TYPE::GAS ).value = { 0., 1., 0. };
+    m_moleComposition.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { 0., 0., 1. };
+
+    m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+    m_lnFugacity.at( pvt::PHASE_TYPE::GAS ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+    m_lnFugacity.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+  }
+  else // nPhases = 2 
+  {
+    // the system is either oil-water or oil-gas
+    
+    m_moleComposition.at( pvt::PHASE_TYPE::OIL ).value = { 1., 0. };
+    m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = { std::log( 1. ), std::log( 1. ) };
+
+    bool const containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.end();
+    if( containsGas )
+    {      
+      m_moleComposition.at( pvt::PHASE_TYPE::GAS ).value = { 0., 1. };
+      m_lnFugacity.at( pvt::PHASE_TYPE::GAS ).value = { std::log( 1. ), std::log( 1. ) };
+    }
+    else
+    {     
+      m_moleComposition.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { 0., 1. };
+      m_lnFugacity.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { std::log( 1. ), std::log( 1. ) };
+    }
+  }
 }
 
 double DeadOilFlashMultiphaseSystemProperties::getOilPhaseMoleFraction() const
@@ -59,9 +88,30 @@ void DeadOilFlashMultiphaseSystemProperties::setFeed( std::vector< double > cons
   FactorMultiphaseSystemProperties::setFeed( feed );
 
   // FIXME Hard coded indices, use constants
+  size_t const nPhases = getPhases().size();
+
+  // TODO: ultimately, all these if statements should go away
+  
   m_phaseMoleFraction.at( pvt::PHASE_TYPE::OIL ).value = feed[0];
-  m_phaseMoleFraction.at( pvt::PHASE_TYPE::GAS ).value = feed[1];
-  m_phaseMoleFraction.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = feed[2];
+  if( nPhases == 3 )
+  {  
+    m_phaseMoleFraction.at( pvt::PHASE_TYPE::GAS ).value = feed[1];
+    m_phaseMoleFraction.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = feed[2];
+  }
+  else // nPhases = 2 
+  {
+    // the system is either oil-water or oil-gas
+    bool const containsGas = std::find( getPhases().cbegin(), getPhases().cend(), pvt::PHASE_TYPE::GAS ) != getPhases().end();
+    if( containsGas )
+    {
+      m_phaseMoleFraction.at( pvt::PHASE_TYPE::GAS ).value = feed[1];
+    }
+    else
+    {
+      m_phaseMoleFraction.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = feed[1];
+    }
+    
+  }
 }
 
 }

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.cpp
@@ -26,7 +26,7 @@ DeadOilFlashMultiphaseSystemProperties::DeadOilFlashMultiphaseSystemProperties( 
   :
   BlackOilDeadOilMultiphaseSystemProperties( phases )
 {
-  size_t const nComponents = phases.size();
+  size_t const nComponents = getNComponents();
   
   for( pvt::PHASE_TYPE pt: getPhases() )
   {

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.cpp
@@ -54,7 +54,7 @@ DeadOilFlashMultiphaseSystemProperties::DeadOilFlashMultiphaseSystemProperties( 
     m_moleComposition.at( pvt::PHASE_TYPE::OIL ).value = { 1., 0. };
     m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = { std::log( 1. ), std::log( 1. ) };
 
-    bool const containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.end();
+    bool const containsGas = std::find( phases.cbegin(), phases.cend(), pvt::PHASE_TYPE::GAS ) != phases.cend();
     if( containsGas )
     {      
       m_moleComposition.at( pvt::PHASE_TYPE::GAS ).value = { 0., 1. };

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/DeadOilFlashMultiphaseSystemProperties.hpp
@@ -31,7 +31,7 @@ class DeadOilFlashMultiphaseSystemProperties : public BlackOilDeadOilMultiphaseS
 {
 public:
 
-  DeadOilFlashMultiphaseSystemProperties( std::size_t nComponents );
+  DeadOilFlashMultiphaseSystemProperties( std::vector< pvt::PHASE_TYPE > const & phases );
 
   double getOilPhaseMoleFraction() const;
 

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.cpp
@@ -27,6 +27,7 @@ FactorMultiphaseSystemProperties::FactorMultiphaseSystemProperties( std::vector<
     m_massDensity.insert( { pt, pvt::ScalarPropertyAndDerivatives< double >( nComponents ) } );
     m_moleComposition.insert( { pt, pvt::VectorPropertyAndDerivatives< double >( nComponents, nComponents ) } );
     m_moleDensity.insert( { pt, pvt::ScalarPropertyAndDerivatives< double >( nComponents ) } );
+    m_viscosity.insert( {pt, pvt::ScalarPropertyAndDerivatives< double >( nComponents ) } ); 
     m_molecularWeight.insert( { pt, pvt::ScalarPropertyAndDerivatives< double >( nComponents ) } );
     m_phaseMoleFraction.insert( { pt, pvt::ScalarPropertyAndDerivatives< double >( nComponents ) } );
   }
@@ -47,6 +48,11 @@ pvt::ScalarPropertyAndDerivatives< double > const & FactorMultiphaseSystemProper
   return m_moleDensity.at( phase );
 }
 
+pvt::ScalarPropertyAndDerivatives< double > const & FactorMultiphaseSystemProperties::getViscosity( pvt::PHASE_TYPE const & phase ) const
+{
+  return m_viscosity.at( phase );
+}
+  
 pvt::ScalarPropertyAndDerivatives< double > const & FactorMultiphaseSystemProperties::getMolecularWeight( pvt::PHASE_TYPE const & phase ) const
 {
   return m_molecularWeight.at( phase );
@@ -119,6 +125,12 @@ void FactorMultiphaseSystemProperties::setMassDensityDP( pvt::PHASE_TYPE const &
   m_massDensity.at( phase ).dP = value;
 }
 
+void FactorMultiphaseSystemProperties::setViscosityDP( pvt::PHASE_TYPE const & phase,
+						       double const & value )
+{
+  m_viscosity.at( phase ).dP = value;
+}
+  
 void FactorMultiphaseSystemProperties::setMoleCompositionDP( pvt::PHASE_TYPE const & phase,
                                                              std::vector< double > const & value )
 {
@@ -153,6 +165,13 @@ void FactorMultiphaseSystemProperties::setMassDensityDZ( pvt::PHASE_TYPE const &
                                                          double const & value )
 {
   m_massDensity.at( phase ).dz[i] = value;
+}
+
+void FactorMultiphaseSystemProperties::setViscosityDZ( pvt::PHASE_TYPE const & phase,
+						       std::size_t i,
+						       double const & value )
+{
+  m_viscosity.at( phase ).dz[i] = value;
 }
 
 void FactorMultiphaseSystemProperties::setMoleCompositionDZ( pvt::PHASE_TYPE const & phase,

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.cpp
@@ -126,7 +126,7 @@ void FactorMultiphaseSystemProperties::setMassDensityDP( pvt::PHASE_TYPE const &
 }
 
 void FactorMultiphaseSystemProperties::setViscosityDP( pvt::PHASE_TYPE const & phase,
-						       double const & value )
+                                                       double const & value )
 {
   m_viscosity.at( phase ).dP = value;
 }
@@ -168,8 +168,8 @@ void FactorMultiphaseSystemProperties::setMassDensityDZ( pvt::PHASE_TYPE const &
 }
 
 void FactorMultiphaseSystemProperties::setViscosityDZ( pvt::PHASE_TYPE const & phase,
-						       std::size_t i,
-						       double const & value )
+                                                       std::size_t i,
+                                                       double const & value )
 {
   m_viscosity.at( phase ).dz[i] = value;
 }

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.hpp
@@ -31,6 +31,8 @@ public:
 
   pvt::ScalarPropertyAndDerivatives< double > const & getMassDensity( pvt::PHASE_TYPE const & phase ) const final;
 
+  pvt::ScalarPropertyAndDerivatives< double > const & getViscosity( pvt::PHASE_TYPE const & phase ) const final;
+  
   pvt::VectorPropertyAndDerivatives< double > const & getMoleComposition( pvt::PHASE_TYPE const & phase ) const final;
 
   pvt::ScalarPropertyAndDerivatives< double > const & getMoleDensity( pvt::PHASE_TYPE const & phase ) const final;
@@ -61,6 +63,9 @@ public:
   void setMassDensityDP( pvt::PHASE_TYPE const & phase,
                          double const & value );
 
+  void setViscosityDP( pvt::PHASE_TYPE const & phase,
+		       double const & value );
+  
   void setMoleCompositionDP( pvt::PHASE_TYPE const & phase,
                              std::vector< double > const & value );
 
@@ -80,6 +85,10 @@ public:
                          std::size_t i,
                          double const & value );
 
+  void setViscosityDZ( pvt::PHASE_TYPE const & phase,
+		       std::size_t i,
+		       double const & value );
+  
   void setMoleCompositionDZ( pvt::PHASE_TYPE const & phase,
                              std::size_t i,
                              std::vector< double > const & value );
@@ -89,9 +98,10 @@ protected:
   std::map< pvt::PHASE_TYPE, pvt::ScalarPropertyAndDerivatives< double > > m_massDensity;
   std::map< pvt::PHASE_TYPE, pvt::VectorPropertyAndDerivatives< double > > m_moleComposition;
   std::map< pvt::PHASE_TYPE, pvt::ScalarPropertyAndDerivatives< double > > m_moleDensity;
+  std::map< pvt::PHASE_TYPE, pvt::ScalarPropertyAndDerivatives< double > > m_viscosity;  
   std::map< pvt::PHASE_TYPE, pvt::ScalarPropertyAndDerivatives< double > > m_molecularWeight;
   std::map< pvt::PHASE_TYPE, pvt::ScalarPropertyAndDerivatives< double > > m_phaseMoleFraction;
-
+  
   void setPhaseMoleFraction( pvt::PHASE_TYPE const & phase,
                              const double & phaseMoleFraction );
 

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/FactorMultiphaseSystemProperties.hpp
@@ -64,7 +64,7 @@ public:
                          double const & value );
 
   void setViscosityDP( pvt::PHASE_TYPE const & phase,
-		       double const & value );
+                       double const & value );
   
   void setMoleCompositionDP( pvt::PHASE_TYPE const & phase,
                              std::vector< double > const & value );
@@ -86,8 +86,8 @@ public:
                          double const & value );
 
   void setViscosityDZ( pvt::PHASE_TYPE const & phase,
-		       std::size_t i,
-		       double const & value );
+                       std::size_t i,
+                       double const & value );
   
   void setMoleCompositionDZ( pvt::PHASE_TYPE const & phase,
                              std::size_t i,

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.cpp
@@ -14,11 +14,21 @@
 
 #include "BlackOil_WaterModel.hpp"
 
+#include "Utils/Logger.hpp"
 #include <cmath>
 
 namespace PVTPackage
 {
 
+BlackOil_WaterModel::BlackOil_WaterModel()
+  :
+  m_surfaceMassDensity( 0.0 ),
+  m_surfaceMoleDensity( 0.0 ),
+  m_surfaceMolecularWeight( 0.0 )
+{
+  // constructor called in DeadOilFlash if water is absent
+}
+  
 BlackOil_WaterModel::BlackOil_WaterModel( const std::vector< double > & PVTW,
                                           double waterSurfaceMassDensity,
                                           double waterSurfaceMolecularWeight )
@@ -28,16 +38,18 @@ BlackOil_WaterModel::BlackOil_WaterModel( const std::vector< double > & PVTW,
 {
   // if water is present, PVTW.size() == 4
   // if water is absent (for two-phase dead-oil), PVTW.size() == 0 => we skip initialization
-  if( PVTW.size() == 4 )
-  {    
-    m_PVTW.ReferencePressure = PVTW[0];
-    m_PVTW.Bw = PVTW[1];
-    m_PVTW.Compressibility = PVTW[2];
-    m_PVTW.Viscosity = PVTW[3];
-
-    //Density
-    m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
+  if( PVTW.size() != 4 )
+  {
+    LOGERROR( "The water PVT table must contain 4 columns" );
   }
+
+  m_PVTW.ReferencePressure = PVTW[0];
+  m_PVTW.Bw = PVTW[1];
+  m_PVTW.Compressibility = PVTW[2];
+  m_PVTW.Viscosity = PVTW[3];
+
+  //Density
+  m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
 }
 
 BlackOilDeadOilProperties BlackOil_WaterModel::computeProperties( double pressure ) const

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.cpp
@@ -20,15 +20,6 @@
 namespace PVTPackage
 {
 
-BlackOil_WaterModel::BlackOil_WaterModel()
-  :
-  m_surfaceMassDensity( 0.0 ),
-  m_surfaceMoleDensity( 0.0 ),
-  m_surfaceMolecularWeight( 0.0 )
-{
-  // constructor called in DeadOilFlash if water is absent
-}
-  
 BlackOil_WaterModel::BlackOil_WaterModel( const std::vector< double > & PVTW,
                                           double waterSurfaceMassDensity,
                                           double waterSurfaceMolecularWeight )

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.cpp
@@ -26,13 +26,18 @@ BlackOil_WaterModel::BlackOil_WaterModel( const std::vector< double > & PVTW,
   m_surfaceMassDensity( waterSurfaceMassDensity ),
   m_surfaceMolecularWeight( waterSurfaceMolecularWeight )
 {
-  m_PVTW.ReferencePressure = PVTW[0];
-  m_PVTW.Bw = PVTW[1];
-  m_PVTW.Compressibility = PVTW[2];
-  m_PVTW.Viscosity = PVTW[3];
+  // if water is present, PVTW.size() == 4
+  // if water is absent (for two-phase dead-oil), PVTW.size() == 0 => we skip initialization
+  if( PVTW.size() == 4 )
+  {    
+    m_PVTW.ReferencePressure = PVTW[0];
+    m_PVTW.Bw = PVTW[1];
+    m_PVTW.Compressibility = PVTW[2];
+    m_PVTW.Viscosity = PVTW[3];
 
-  //Density
-  m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
+    //Density
+    m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
+  }
 }
 
 BlackOilDeadOilProperties BlackOil_WaterModel::computeProperties( double pressure ) const

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.hpp
@@ -43,8 +43,6 @@ public:
     // Left blank
   }
 
-  BlackOil_WaterModel();
-  
   BlackOil_WaterModel( const std::vector< double > & PVTW,
                        double waterSurfaceMassDensity,
                        double waterSurfaceMolecularWeight );

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_WaterModel.hpp
@@ -43,6 +43,8 @@ public:
     // Left blank
   }
 
+  BlackOil_WaterModel();
+  
   BlackOil_WaterModel( const std::vector< double > & PVTW,
                        double waterSurfaceMassDensity,
                        double waterSurfaceMolecularWeight );

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
@@ -22,15 +22,6 @@
 namespace PVTPackage
 {
 
-DeadOil_PhaseModel::DeadOil_PhaseModel( pvt::PHASE_TYPE type )
-  : m_type( type ),
-    m_surfaceMassDensity( 0 ),
-    m_surfaceMoleDensity( 0 ),
-    m_surfaceMolecularWeight( 0 )
-{
-  // constructor called by DeadOilFlash if the (gas) phase is absent  
-}
-  
 DeadOil_PhaseModel::DeadOil_PhaseModel( pvt::PHASE_TYPE type,
                                         const std::vector< std::vector< double > > & PVD,
                                         double oilSurfaceMassDensity,

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
@@ -31,19 +31,25 @@ DeadOil_PhaseModel::DeadOil_PhaseModel( pvt::PHASE_TYPE type,
     m_surfaceMoleDensity( 0 ),
     m_surfaceMolecularWeight( oilSurfaceMw )
 {
+  // if the phase is present, PVTD.size() > 0
+  // if the phase is absent (for two-phase dead-oil), PVD.size() == 0 => we skip initialization
+  if( PVD.size() > 0 )
+  {    
+  
+    // Fill table
+    createTable( PVD );
 
-  //--Fill table
-  createTable( PVD );
+    // Check consistency
+    checkTableConsistency();
 
-  //Check Consistency
-  checkTableConsistency();
+    // Check consistency
+    checkTableConsistency();
 
-  //Check Consistency
-  checkTableConsistency();
-
-  //Density
-  m_surfaceMassDensity = oilSurfaceMassDensity;
-  m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
+    // Compute density
+    m_surfaceMassDensity = oilSurfaceMassDensity;
+    m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
+    
+  }
 }
 
 void DeadOil_PhaseModel::checkTableConsistency()
@@ -87,15 +93,7 @@ void DeadOil_PhaseModel::createTable( const std::vector< std::vector< double>> &
     m_PVD.Viscosity[i] = PVD[i][2];
   }
 
-  //Add 1atm value if does not exist yet
-  auto Pref = 101325.0;
-  if( !math::isNearlyEqual( m_PVD.Pressure[0], Pref ) )
-  {
-    m_PVD.Pressure.insert( m_PVD.Pressure.begin(), Pref );
-    m_PVD.NPoints++;
-  }
-
-  //
+  // find the min and max pressure in the table
   m_maxPressure = *( std::max_element( m_PVD.Pressure.begin(), m_PVD.Pressure.end() ) );
   m_minPressure = *( std::min_element( m_PVD.Pressure.begin(), m_PVD.Pressure.end() ) );
 }

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
@@ -22,6 +22,15 @@
 namespace PVTPackage
 {
 
+DeadOil_PhaseModel::DeadOil_PhaseModel( pvt::PHASE_TYPE type )
+  : m_type( type ),
+    m_surfaceMassDensity( 0 ),
+    m_surfaceMoleDensity( 0 ),
+    m_surfaceMolecularWeight( 0 )
+{
+  // constructor called by DeadOilFlash if the (gas) phase is absent  
+}
+  
 DeadOil_PhaseModel::DeadOil_PhaseModel( pvt::PHASE_TYPE type,
                                         const std::vector< std::vector< double > > & PVD,
                                         double oilSurfaceMassDensity,
@@ -31,25 +40,24 @@ DeadOil_PhaseModel::DeadOil_PhaseModel( pvt::PHASE_TYPE type,
     m_surfaceMoleDensity( 0 ),
     m_surfaceMolecularWeight( oilSurfaceMw )
 {
-  // if the phase is present, PVTD.size() > 0
-  // if the phase is absent (for two-phase dead-oil), PVD.size() == 0 => we skip initialization
-  if( PVD.size() > 0 )
-  {    
-  
-    // Fill table
-    createTable( PVD );
-
-    // Check consistency
-    checkTableConsistency();
-
-    // Check consistency
-    checkTableConsistency();
-
-    // Compute density
-    m_surfaceMassDensity = oilSurfaceMassDensity;
-    m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
-    
+  // if the phase is present, PVTD.size() == 3
+  if( PVD[0].size() != 3 )
+  {
+    LOGERROR( "The PVD table must contain 3 columns" );
   }
+
+  // Fill table
+  createTable( PVD );
+
+  // Check consistency
+  checkTableConsistency();
+
+  // Check consistency
+  checkTableConsistency();
+  
+  // Compute density
+  m_surfaceMassDensity = oilSurfaceMassDensity;
+  m_surfaceMoleDensity = m_surfaceMassDensity / m_surfaceMolecularWeight;
 }
 
 void DeadOil_PhaseModel::checkTableConsistency()

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.hpp
@@ -55,6 +55,8 @@ public:
                       double oilSurfaceMassDensity,
                       double oilSurfaceMw );
 
+  DeadOil_PhaseModel( pvt::PHASE_TYPE type );
+  
   //Getter
   double getSurfaceMassDensity() const
   {

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.hpp
@@ -55,8 +55,6 @@ public:
                       double oilSurfaceMassDensity,
                       double oilSurfaceMw );
 
-  DeadOil_PhaseModel( pvt::PHASE_TYPE type );
-  
   //Getter
   double getSurfaceMassDensity() const
   {

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/CubicEOS/CubicEoSPhaseModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/CubicEOS/CubicEoSPhaseModel.cpp
@@ -31,9 +31,10 @@ CubicEoSPhaseModel::Properties CubicEoSPhaseModel::computeAllProperties( double 
   const double moleDensity = computeMoleDensity( m_componentProperties, pressure, temperature, composition, compressibilityFactor );
   const double molecularWeight = computeMolecularWeight( m_componentProperties, composition );
   const double massDensity = computeMassDensity( moleDensity, molecularWeight );
-
+  const double viscosity = computeViscosity();
+  
   return Properties{
-    compressibilityFactor, massDensity, moleDensity, molecularWeight, lnFugacitiesCoeffs
+    compressibilityFactor, massDensity, moleDensity, viscosity, molecularWeight, lnFugacitiesCoeffs
   };
 }
 
@@ -206,6 +207,13 @@ double CubicEoSPhaseModel::computeMassDensity( double moleDensity,
                                                double mw )
 {
   return moleDensity * mw;
+}
+
+double CubicEoSPhaseModel::computeViscosity()
+{
+  // TODO: implement correlations here
+  // needs componentProperties, pressure, temperature, composition
+  return 0.001; 
 }
 
 void CubicEoSPhaseModel::init()

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/CubicEOS/CubicEoSPhaseModel.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/CubicEOS/CubicEoSPhaseModel.hpp
@@ -61,6 +61,7 @@ public:
     double compressibilityFactor;
     double massDensity;
     double moleDensity;
+    double viscosity;
     double molecularWeight;
     std::vector< double > lnFugacityCoefficients;
   };
@@ -130,6 +131,8 @@ private:
   static double computeMassDensity( double moleDensity,
                                     double mw );
 
+  static double computeViscosity(); 
+  
   std::vector< double > computeLnFugacitiesCoefficients( std::vector< double > const & composition,
                                                          double Z,
                                                          CubicEosMixtureCoefficients const & mixtureCoefficients ) const;

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
@@ -70,13 +70,11 @@ DeadOil_PhaseModel const & DeadOilFlash::getOilPhaseModel() const
   
 DeadOil_PhaseModel const & DeadOilFlash::getGasPhaseModel() const
 {
-  // Warning! the result returned by this function will be void for a two-phase oil-water model
   return *m_gasPhaseModel;
 }
 
 BlackOil_WaterModel const & DeadOilFlash::getWaterPhaseModel() const
 {
-  // Warning! the result returned by this function will be void for a two-phase oil-gas model  
   return *m_waterPhaseModel;
 }
 

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
@@ -34,10 +34,8 @@ DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
   :
   m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight )
 {
-  DeadOil_PhaseModel * ptr1 = new DeadOil_PhaseModel( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight );
-  m_gasPhaseModel = std::unique_ptr< DeadOil_PhaseModel >( ptr1 );
-  BlackOil_WaterModel * ptr2 = new BlackOil_WaterModel( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight );
-  m_waterPhaseModel = std::unique_ptr< BlackOil_WaterModel >( ptr2 );      
+  m_gasPhaseModel = std::make_unique< DeadOil_PhaseModel >( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight );
+  m_waterPhaseModel = std::make_unique< BlackOil_WaterModel >( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight );  
 }
 
 DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
@@ -49,8 +47,7 @@ DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
   :
   m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight )
 {
-  DeadOil_PhaseModel * ptr = new DeadOil_PhaseModel( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight );
-  m_gasPhaseModel = std::unique_ptr< DeadOil_PhaseModel >( ptr );
+  m_gasPhaseModel = std::make_unique< DeadOil_PhaseModel >( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight );
 }
 
 DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
@@ -62,8 +59,7 @@ DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
   :
   m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight )
 {
-  BlackOil_WaterModel * ptr = new BlackOil_WaterModel( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight );
-  m_waterPhaseModel = std::unique_ptr< BlackOil_WaterModel >( ptr );    
+  m_waterPhaseModel = std::make_unique< BlackOil_WaterModel >( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight );
 }
   
 DeadOil_PhaseModel const & DeadOilFlash::getOilPhaseModel() const
@@ -71,13 +67,16 @@ DeadOil_PhaseModel const & DeadOilFlash::getOilPhaseModel() const
   return m_oilPhaseModel;
 }
 
+  
 DeadOil_PhaseModel const & DeadOilFlash::getGasPhaseModel() const
 {
+  // Warning! the result returned by this function will be void for a two-phase oil-water model
   return *m_gasPhaseModel;
 }
 
 BlackOil_WaterModel const & DeadOilFlash::getWaterPhaseModel() const
 {
+  // Warning! the result returned by this function will be void for a two-phase oil-gas model  
   return *m_waterPhaseModel;
 }
 

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
@@ -90,11 +90,6 @@ bool DeadOilFlash::computeEquilibrium( DeadOilFlashMultiphaseSystemProperties & 
                                         sysProps.getPhases().cend(),
                                         pvt::PHASE_TYPE::LIQUID_WATER_RICH ) != sysProps.getPhases().cend();
 
-  if( containsGas == containsWater )
-  {
-
-  }
-  
   // OIL
   const DeadOil_PhaseModel & oilPhaseModel = getOilPhaseModel();  
   auto const oilProps = oilPhaseModel.computeProperties( pressure );

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.cpp
@@ -32,10 +32,12 @@ DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
                             double waterSurfaceMassDensity,
                             double waterSurfaceMolecularWeight )
   :
-  m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight ),
-  m_gasPhaseModel( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight ),
-  m_waterPhaseModel( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight )
+  m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight )
 {
+  DeadOil_PhaseModel * ptr1 = new DeadOil_PhaseModel( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight );
+  m_gasPhaseModel = std::unique_ptr< DeadOil_PhaseModel >( ptr1 );
+  BlackOil_WaterModel * ptr2 = new BlackOil_WaterModel( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight );
+  m_waterPhaseModel = std::unique_ptr< BlackOil_WaterModel >( ptr2 );      
 }
 
 DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
@@ -45,10 +47,10 @@ DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
                             double gasSurfaceMassDensity,
                             double gasSurfaceMolecularWeight )
   :
-  m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight ),
-  m_gasPhaseModel( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight ),
-  m_waterPhaseModel()  
+  m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight )
 {
+  DeadOil_PhaseModel * ptr = new DeadOil_PhaseModel( pvt::PHASE_TYPE::GAS, PVDG, gasSurfaceMassDensity, gasSurfaceMolecularWeight );
+  m_gasPhaseModel = std::unique_ptr< DeadOil_PhaseModel >( ptr );
 }
 
 DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
@@ -58,10 +60,10 @@ DeadOilFlash::DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
                             double waterSurfaceMassDensity,
                             double waterSurfaceMolecularWeight )
   :
-  m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight ),
-  m_gasPhaseModel( pvt::PHASE_TYPE::GAS ),  
-  m_waterPhaseModel( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight )
+  m_oilPhaseModel( pvt::PHASE_TYPE::OIL, PVDO, oilSurfaceMassDensity, oilSurfaceMolecularWeight )
 {
+  BlackOil_WaterModel * ptr = new BlackOil_WaterModel( PVTW, waterSurfaceMassDensity, waterSurfaceMolecularWeight );
+  m_waterPhaseModel = std::unique_ptr< BlackOil_WaterModel >( ptr );    
 }
   
 DeadOil_PhaseModel const & DeadOilFlash::getOilPhaseModel() const
@@ -71,12 +73,12 @@ DeadOil_PhaseModel const & DeadOilFlash::getOilPhaseModel() const
 
 DeadOil_PhaseModel const & DeadOilFlash::getGasPhaseModel() const
 {
-  return m_gasPhaseModel;
+  return *m_gasPhaseModel;
 }
 
 BlackOil_WaterModel const & DeadOilFlash::getWaterPhaseModel() const
 {
-  return m_waterPhaseModel;
+  return *m_waterPhaseModel;
 }
 
 bool DeadOilFlash::computeEquilibrium( DeadOilFlashMultiphaseSystemProperties & sysProps ) const

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
@@ -69,8 +69,8 @@ public:
 private:
 
   DeadOil_PhaseModel m_oilPhaseModel;
-  DeadOil_PhaseModel m_gasPhaseModel;
-  BlackOil_WaterModel m_waterPhaseModel;
+  std::unique_ptr< DeadOil_PhaseModel > m_gasPhaseModel;
+  std::unique_ptr< BlackOil_WaterModel > m_waterPhaseModel;
 };
 
 }

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
@@ -60,8 +60,14 @@ public:
   
   DeadOil_PhaseModel const & getOilPhaseModel() const;
 
+  /**
+   * @brief Warning! the result returned by this function will be void for a two-phase oil-water model  
+   */
   DeadOil_PhaseModel const & getGasPhaseModel() const;
 
+  /**
+   * @brief Warning! the result returned by this function will be void for a two-phase oil-gas model  
+   */
   BlackOil_WaterModel const & getWaterPhaseModel() const;
 
   bool computeEquilibrium( DeadOilFlashMultiphaseSystemProperties & sysProps ) const;

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
@@ -25,6 +25,9 @@ class DeadOilFlash
 {
 public:
 
+  /**
+   * @brief Constructor for the three-phase Dead-Oil model
+   */  
   DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
                 double oilSurfaceMassDensity,
                 double oilSurfaceMolecularWeight,
@@ -35,6 +38,9 @@ public:
                 double waterSurfaceMassDensity,
                 double waterSurfaceMolecularWeight );
 
+  /**
+   * @brief Constructor for the two-phase oil-gas Dead-Oil model
+   */  
   DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
                 double oilSurfaceMassDensity,
                 double oilSurfaceMolecularWeight,
@@ -42,6 +48,9 @@ public:
                 double gasSurfaceMassDensity,
                 double gasSurfaceMolecularWeight );
 
+  /**
+   * @brief Constructor for the two-phase oil-water Dead-Oil model
+   */  
   DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
                 double oilSurfaceMassDensity,
                 double oilSurfaceMolecularWeight,

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/DeadOilFlash.hpp
@@ -35,6 +35,20 @@ public:
                 double waterSurfaceMassDensity,
                 double waterSurfaceMolecularWeight );
 
+  DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
+                double oilSurfaceMassDensity,
+                double oilSurfaceMolecularWeight,
+                std::vector< std::vector< double > > const & PVDG,
+                double gasSurfaceMassDensity,
+                double gasSurfaceMolecularWeight );
+
+  DeadOilFlash( std::vector< std::vector< double > > const & PVDO,
+                double oilSurfaceMassDensity,
+                double oilSurfaceMolecularWeight,
+                std::vector< double > const & PVTW,
+                double waterSurfaceMassDensity,
+                double waterSurfaceMolecularWeight );
+  
   DeadOil_PhaseModel const & getOilPhaseModel() const;
 
   DeadOil_PhaseModel const & getGasPhaseModel() const;

--- a/PVTPackage/source/pvt/pvt.hpp
+++ b/PVTPackage/source/pvt/pvt.hpp
@@ -131,6 +131,14 @@ public:
   virtual const ScalarPropertyAndDerivatives< double > & getMoleDensity( PHASE_TYPE const & phase ) const = 0;
 
   /**
+   * @brief Viscosity data (and derivatives) for given @p phase.
+   * @param phase The required phase (oil, gas, water).
+   * @return The data as a ref to const.
+   * @throw std::out_of_range if @p phase does not exist.
+   */
+  virtual const ScalarPropertyAndDerivatives< double > & getViscosity( PHASE_TYPE const & phase ) const = 0;
+
+  /**
    * @brief Molecular weight data (and derivatives) for given @p phase.
    * @param phase The required phase (oil, gas, water).
    * @return The data as a ref to const.


### PR DESCRIPTION
This PR modifies the DO model to allow for immiscible two-phase systems (oil-water, or oil-gas). This is very useful on the GEOSX side when one wants to simplify the fluid behavior as much as possible, and this is used in well-known benchmarks (see SPE10 and Egg models for instance).

This PR also makes it possible to read fluid viscosities from PVT tables (they were previously hard-coded on the GEOSX side) for DO and BO models. For true compositional models, we still need to add correlations.

@TotoGaz This is really not urgent and can wait until you come back. We can then work on the following points:
- The changes that I made to have a two-phase DO model (making `nPhases` a runtime variable) are orthogonal to what will be needed on the GPU, so let's revisit together what I have done in this PR.
- We can implement the viscosity correlations for true compositional models.

Related to GEOSX/GEOSX#1240

Also fixes #29 