### PR TITLE
Removed ASSERT preventing from running tutorials in Debug

### DIFF
--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/DeadOil_PhaseModel.cpp
@@ -59,19 +59,10 @@ void DeadOil_PhaseModel::checkTableConsistency()
   //Check for saturated region
   for( std::size_t i = 0; i < m_PVD.NPoints - 1; ++i )
   {
-    if( m_type == pvt::PHASE_TYPE::OIL )
-    {
-      //Bo must increase with P
-      ASSERT( ( m_PVD.B[i + 1] - m_PVD.B[i] ) > 0, "Bo must increase with P" );
-      //Visc must decrease with P
-      ASSERT( ( m_PVD.Viscosity[i + 1] - m_PVD.Viscosity[i] ) < 0, "Viscosity must increase with P" );
-    }
-    else if( m_type == pvt::PHASE_TYPE::GAS )
+    if( m_type == pvt::PHASE_TYPE::GAS )
     {
       //Bg must decrease with P
-      ASSERT( ( m_PVD.B[i + 1] - m_PVD.B[i] ) < 0, "Bo must increase with P" );
-      //Visc must increase with P
-      ASSERT( ( m_PVD.Viscosity[i + 1] - m_PVD.Viscosity[i] ) > 0, "Viscosity must increase with P" );
+      ASSERT( ( m_PVD.B[i + 1] - m_PVD.B[i] ) < 0, "Bg must increase with P" );
     }
   }
 }


### PR DESCRIPTION
This PR removes some `ASSERT`s in the Dead-Oil model that prevent us from running some published tests cases:
- SPE10: the oil formation volume factor must be allowed to decrease as a function of pressure: [here](https://www.spe.org/web/csp/datasets/set02.htm)
- Egg: the oil viscosity must be allowed to be a constant function of pressure: [here](https://rmets.onlinelibrary.wiley.com/doi/pdf/10.1002/gdj3.21)