### PR TITLE
Fixes for the BO model

### DIFF
--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilDeadOilMultiphaseSystemProperties.cpp
@@ -36,7 +36,7 @@ void BlackOilDeadOilMultiphaseSystemProperties::setModelProperties( pvt::PHASE_T
   m_massDensity.at( phase ).value = props.massDensity;
   m_moleDensity.at( phase ).value = props.moleDensity;
   m_viscosity.at( phase ).value = props.viscosity;
-  m_molecularWeight.at( phase ).value = props.massDensity / props.moleDensity;
+  m_molecularWeight.at( phase ).value = props.moleDensity > 0 ? props.massDensity / props.moleDensity : 0.0;
 }
 
 void BlackOilDeadOilMultiphaseSystemProperties::setOilModelProperties( BlackOilDeadOilProperties const & props )

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
@@ -14,6 +14,8 @@
 
 #include "BlackOilFlashMultiphaseSystemProperties.hpp"
 
+#include <cmath>
+
 namespace PVTPackage
 {
 
@@ -28,6 +30,10 @@ BlackOilFlashMultiphaseSystemProperties::BlackOilFlashMultiphaseSystemProperties
     m_lnFugacity.insert( { pt, pvt::VectorPropertyAndDerivatives< double >( nComponents, nComponents ) } );
   }
 
+  m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+  m_lnFugacity.at( pvt::PHASE_TYPE::GAS ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+  m_lnFugacity.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
+  
   m_moleComposition.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { 0., 0., 1. };
 }
 

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
@@ -14,8 +14,6 @@
 
 #include "BlackOilFlashMultiphaseSystemProperties.hpp"
 
-#include <cmath>
-
 namespace PVTPackage
 {
 
@@ -29,10 +27,6 @@ BlackOilFlashMultiphaseSystemProperties::BlackOilFlashMultiphaseSystemProperties
   {
     m_lnFugacity.insert( { pt, pvt::VectorPropertyAndDerivatives< double >( nComponents, nComponents ) } );
   }
-
-  m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
-  m_lnFugacity.at( pvt::PHASE_TYPE::GAS ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
-  m_lnFugacity.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { std::log( 1. ), std::log( 1. ), std::log( 1. ) };
   
   m_moleComposition.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = { 0., 0., 1. };
 }

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.cpp
@@ -56,19 +56,4 @@ void BlackOilFlashMultiphaseSystemProperties::setGasMoleComposition( std::vector
   setMoleComposition( pvt::PHASE_TYPE::GAS, moleComposition );
 }
 
-void BlackOilFlashMultiphaseSystemProperties::setOilLnFugacity( std::vector< double > const & lnFugacity )
-{
-  m_lnFugacity.at( pvt::PHASE_TYPE::OIL ).value = lnFugacity;
-}
-
-void BlackOilFlashMultiphaseSystemProperties::setGasLnFugacity( std::vector< double > const & lnFugacity )
-{
-  m_lnFugacity.at( pvt::PHASE_TYPE::GAS ).value = lnFugacity;
-}
-
-void BlackOilFlashMultiphaseSystemProperties::setWaterLnFugacity( std::vector< double > const & lnFugacity )
-{
-  m_lnFugacity.at( pvt::PHASE_TYPE::LIQUID_WATER_RICH ).value = lnFugacity;
-}
-
 } // end of namespace PVTPackage

--- a/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.hpp
+++ b/PVTPackage/source/MultiphaseSystem/MultiphaseSystemProperties/BlackOilFlashMultiphaseSystemProperties.hpp
@@ -40,12 +40,6 @@ public:
 
   void setGasMoleComposition( std::vector< double > const & moleComposition );
 
-  void setOilLnFugacity( std::vector< double > const & lnFugacity );
-
-  void setGasLnFugacity( std::vector< double > const & lnFugacity );
-
-  void setWaterLnFugacity( std::vector< double > const & lnFugacity );
-
 private:
 
   std::map< pvt::PHASE_TYPE, pvt::VectorPropertyAndDerivatives< double > > m_lnFugacity;

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_GasModel.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_GasModel.cpp
@@ -276,7 +276,7 @@ BlackOilDeadOilProperties BlackOil_GasModel::computeSaturatedProperties( double 
   ASSERT( ( Pdew < m_maxPressure ) & ( Pdew > m_minPressure ), "Pressure out of table range" );
   auto Rv = computeRv( Pdew );
   double Bg, viscosity;
-  computeSaturatedBgVisc( Rv, Bg, viscosity );
+  computeBgVisc( Pdew, Bg, viscosity );
 
   return BlackOilDeadOilProperties(
     computeMassDensity( Rv, Bg, oilMassSurfaceDensity ),
@@ -285,19 +285,18 @@ BlackOilDeadOilProperties BlackOil_GasModel::computeSaturatedProperties( double 
   );
 }
 
-void BlackOil_GasModel::computeSaturatedBgVisc( double Rv,
-                                                double & Bg,
-                                                double & viscosity ) const
+void BlackOil_GasModel::computeBgVisc( const double & pres,
+                                       double & Bg,
+                                       double & viscosity ) const
 {
-  std::size_t i_lower_branch, i_upper_branch;
-  auto const & Rs_vec = m_PVTG.Rv;
+  std::size_t i_lower, i_upper;
   auto const & Bg_vec = m_PVTG.SaturatedBg;
   auto const & visc_vec = m_PVTG.SaturatedViscosity;
-  math::FindSurrondingIndex( Rs_vec, Rv, i_lower_branch, i_upper_branch );
-  Bg = math::LinearInterpolation( Rv - Rs_vec[i_lower_branch], Rs_vec[i_upper_branch] - Rv, Bg_vec[i_lower_branch], Bg_vec[i_upper_branch] );
-  viscosity = math::LinearInterpolation( Rv - Rs_vec[i_lower_branch], Rs_vec[i_upper_branch] - Rv, visc_vec[i_lower_branch], visc_vec[i_upper_branch] );
+  math::FindSurrondingIndex( m_PVTG.DewPressure, pres, i_lower, i_upper );
+  Bg = math::LinearInterpolation( m_PVTG.DewPressure[i_lower], Bg_vec[i_lower], m_PVTG.DewPressure[i_upper], Bg_vec[i_upper] );
+  viscosity = math::LinearInterpolation( m_PVTG.DewPressure[i_lower], visc_vec[i_lower], m_PVTG.DewPressure[i_upper], visc_vec[i_upper] );
 }
-
+  
 double BlackOil_GasModel::computeMoleDensity( double Rv,
                                               double Bg,
                                               double surfaceOilMoleDensity ) const

--- a/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_GasModel.hpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseModel/BlackOil/BlackOil_GasModel.hpp
@@ -68,10 +68,10 @@ private:
 
   double computePdew( double Rv ) const;
 
-  void computeSaturatedBgVisc( double Rv,
-                               double & Bg,
-                               double & viscosity ) const;
-
+  void computeBgVisc( const double & pres,
+                      double & Bg,
+                      double & viscosity ) const;
+  
   double computeMoleDensity( double Rv,
                              double Bg,
                              double surfaceOilMoleDensity ) const;

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/BlackOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/BlackOilFlash.cpp
@@ -44,89 +44,105 @@ bool BlackOilFlash::computeEquilibrium( BlackOilFlashMultiphaseSystemProperties 
   const std::vector< double > & feed = sysProps.getFeed();
   const double zo = feed[0], zg = feed[1], zw = feed[2];
 
-  // OIL
-  const double & oilSurfaceMoleDensity = m_oilPhaseModel.getSurfaceMoleDensity();
-  const double & oilSurfaceMassDensity = m_oilPhaseModel.getSurfaceMassDensity();
-  const double rsSat = m_oilPhaseModel.computeRs( pressure );
-
-  // GAS
-  const double & gasSurfaceMoleDensity = m_gasPhaseModel.getSurfaceMoleDensity();
-  const double & gasSurfaceMassDensity = m_gasPhaseModel.getSurfaceMassDensity();
-  const double rvSat = m_gasPhaseModel.computeRv( pressure );
-
-  // Phase State - Negative flash type
-  double const Ko = rvSat * ( oilSurfaceMoleDensity + gasSurfaceMoleDensity * rsSat ) / ( gasSurfaceMoleDensity + oilSurfaceMoleDensity * rvSat );
-  double const Kg = ( oilSurfaceMoleDensity + gasSurfaceMoleDensity * rsSat ) / ( rsSat * ( gasSurfaceMoleDensity + oilSurfaceMoleDensity * rvSat ) );
-  double const V = zo / ( 1. - Kg ) + zg / ( 1. - Ko );
-
-  if( ( 0 < V ) && ( V < 1 ) )  //Two-phase or both oil and gas saturated
+  // check feed first, and if only water is present (e.g., pure water injection), do nothing
+  if( zw >= 1.0 )
   {
-    // Phase Fractions
-    sysProps.setOilFraction( 1. - V - zw );
-    sysProps.setGasFraction( V );
+    // phase fractions
+    sysProps.setOilFraction( 0.0 );
+    sysProps.setGasFraction( 0.0 );
     sysProps.setWaterFraction( zw );
+
+    // compositions
+    const std::vector< double > zeroMoleComposition{ 0.0, 0.0, 0.0 };
+    sysProps.setOilMoleComposition( zeroMoleComposition );
+    sysProps.setGasMoleComposition( zeroMoleComposition );
+    
+    // density, viscosity
+    BlackOilDeadOilProperties tmp( 0.0, 0.0, 0.0 );
+    sysProps.setOilModelProperties( tmp );
+    sysProps.setGasModelProperties( tmp );
+
+    // fugacities
+    sysProps.setOilLnFugacity( { std::log( 1.0 ), std::log( 1.0 ), std::log( 1.0 ) } );
+    sysProps.setGasLnFugacity( { std::log( 1.0 ), std::log( 1.0 ), std::log( 1.0 ) } );
+    sysProps.setWaterLnFugacity( { std::log( 1.0 ), std::log( 1.0 ), std::log( 1.0 ) } );        
+
+    // water
+    auto const waterProperties = m_waterPhaseModel.computeProperties( pressure );
+    sysProps.setWaterModelProperties( waterProperties );
+    
+    return true;
+  }
+  else
+  {    
     // OIL
-    const double tmpOil = oilSurfaceMoleDensity / ( oilSurfaceMoleDensity + gasSurfaceMoleDensity * rsSat );
-    const std::vector< double > oilMoleComposition{ tmpOil, 1. - tmpOil, 0. }; // FIXME always 0.
-    sysProps.setOilMoleComposition( oilMoleComposition );
-
-    auto const oilSaturatedProperties = m_oilPhaseModel.computeSaturatedProperties( pressure, gasSurfaceMoleDensity, gasSurfaceMassDensity );
-    sysProps.setOilModelProperties( oilSaturatedProperties );
-
+    const double & oilSurfaceMoleDensity = m_oilPhaseModel.getSurfaceMoleDensity();
+    const double & oilSurfaceMassDensity = m_oilPhaseModel.getSurfaceMassDensity();
+    const double rsSat = m_oilPhaseModel.computeRs( pressure );
+    
     // GAS
-    const double tmpGas = gasSurfaceMoleDensity / ( gasSurfaceMoleDensity + oilSurfaceMoleDensity * rvSat );
-    const std::vector< double > gasMoleComposition{ 1. - tmpGas, tmpGas, 0. }; // FIXME always 0.
-    sysProps.setGasMoleComposition( gasMoleComposition );
+    const double & gasSurfaceMoleDensity = m_gasPhaseModel.getSurfaceMoleDensity();
+    const double & gasSurfaceMassDensity = m_gasPhaseModel.getSurfaceMassDensity();
+    const double rvSat = m_gasPhaseModel.computeRv( pressure );
 
-    auto const gasSaturatedProperties = m_gasPhaseModel.computeSaturatedProperties( pressure, oilSurfaceMoleDensity, oilSurfaceMassDensity );
-    sysProps.setGasModelProperties( gasSaturatedProperties );
+    // Phase State - Negative flash type
+    double const Ko = rvSat * ( oilSurfaceMoleDensity + gasSurfaceMoleDensity * rsSat ) / ( gasSurfaceMoleDensity + oilSurfaceMoleDensity * rvSat );
+    double const Kg = ( oilSurfaceMoleDensity + gasSurfaceMoleDensity * rsSat ) / ( rsSat * ( gasSurfaceMoleDensity + oilSurfaceMoleDensity * rvSat ) );
+    double const V = zo / ( 1. - Kg ) + zg / ( 1. - Ko );
+  
+    if( ( 0 < V ) && ( V < 1 ) )  //Two-phase or both oil and gas saturated
+    {
+      // Phase Fractions
+      sysProps.setOilFraction( 1. - V - zw );
+      sysProps.setGasFraction( V );
+      sysProps.setWaterFraction( zw );
+      // OIL
+      const double tmpOil = oilSurfaceMoleDensity / ( oilSurfaceMoleDensity + gasSurfaceMoleDensity * rsSat );
+      const std::vector< double > oilMoleComposition{ tmpOil, 1. - tmpOil, 0. }; // FIXME always 0.
+      sysProps.setOilMoleComposition( oilMoleComposition );
 
-    // Oil ln fugacity
-    const std::vector< double > oilLnFugacity{
-      std::log( oilMoleComposition[0] * Ko * pressure ),
-      std::log( oilMoleComposition[1] * Kg * pressure ),
-      std::log( 1. )
-    };
-    sysProps.setOilLnFugacity( oilLnFugacity );
+      auto const oilSaturatedProperties = m_oilPhaseModel.computeSaturatedProperties( pressure, gasSurfaceMoleDensity, gasSurfaceMassDensity );
+      sysProps.setOilModelProperties( oilSaturatedProperties );
+    
+      // GAS
+      const double tmpGas = gasSurfaceMoleDensity / ( gasSurfaceMoleDensity + oilSurfaceMoleDensity * rvSat );
+      const std::vector< double > gasMoleComposition{ 1. - tmpGas, tmpGas, 0. }; // FIXME always 0.
+      sysProps.setGasMoleComposition( gasMoleComposition );
+      
+      auto const gasSaturatedProperties = m_gasPhaseModel.computeSaturatedProperties( pressure, oilSurfaceMoleDensity, oilSurfaceMassDensity );
+      sysProps.setGasModelProperties( gasSaturatedProperties );
 
-    // Gas and water ln fugacity
-    const std::vector< double > gasAndWaterLnFugacity{
-      std::log( gasMoleComposition[0] * pressure ),
-      std::log( gasMoleComposition[1] * pressure ),
-      std::log( 1. ) // FIXME water fugacities are always std::log( 1. )
-    };
-    sysProps.setGasLnFugacity( gasAndWaterLnFugacity );
-    sysProps.setWaterLnFugacity( gasAndWaterLnFugacity ); // FIXME It's the same values for water and gas?
+    }
+    else if( V > 1 ) //Only gas or undersaturated gas
+    {
+      LOGERROR( "Undersaturated gas not supported yet" );
+    }
+    else // Only oil or undersaturated oil
+    {
+      // Phase Fractions
+      sysProps.setOilFraction( 1. - zw );
+      sysProps.setGasFraction( 0. );
+      sysProps.setWaterFraction( zw );
+
+      // OIL
+      std::vector< double > const oilMoleComposition{ zo, zg, 0. }; // FIXME always 0.
+      sysProps.setOilMoleComposition( oilMoleComposition );
+      auto const oilUnderSaturatedProperties = m_oilPhaseModel.computeUnderSaturatedProperties( pressure, oilMoleComposition, gasSurfaceMoleDensity, gasSurfaceMassDensity );
+      sysProps.setOilModelProperties( oilUnderSaturatedProperties );
+
+      // LN FUGACITIES
+      sysProps.setOilLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
+      sysProps.setGasLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
+      sysProps.setWaterLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
+    }
+
+    // Water
+    auto const waterProperties = m_waterPhaseModel.computeProperties( pressure );
+    sysProps.setWaterModelProperties( waterProperties );
+    // FIXME be sure that waterComp = {0, 0, 1} is done...
+
+    return true;
   }
-  else if( V > 1 ) //Only gas or undersaturated gas
-  {
-    LOGERROR( "Undersaturated gas not supported yet" );
-  }
-  else // Only oil or undersaturated oil
-  {
-    // Phase Fractions
-    sysProps.setOilFraction( 1. - zw );
-    sysProps.setGasFraction( 0. );
-    sysProps.setWaterFraction( zw );
-
-    // OIL
-    std::vector< double > const oilMoleComposition{ zo, zg, 0. }; // FIXME always 0.
-    sysProps.setOilMoleComposition( oilMoleComposition );
-    auto const oilUnderSaturatedProperties = m_oilPhaseModel.computeUnderSaturatedProperties( pressure, oilMoleComposition, gasSurfaceMoleDensity, gasSurfaceMassDensity );
-    sysProps.setOilModelProperties( oilUnderSaturatedProperties );
-
-    // LN FUGACITIES
-    sysProps.setOilLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
-    sysProps.setGasLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
-    sysProps.setWaterLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
-  }
-
-  // Water
-  auto const waterProperties = m_waterPhaseModel.computeProperties( pressure );
-  sysProps.setWaterModelProperties( waterProperties );
-  // FIXME be sure that waterComp = {0, 0, 1} is done...
-
-  return true;
 }
 
 }

--- a/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/BlackOilFlash.cpp
+++ b/PVTPackage/source/MultiphaseSystem/PhaseSplitModel/BlackOilFlash.cpp
@@ -14,8 +14,6 @@
 
 #include "BlackOilFlash.hpp"
 
-#include <cmath>
-
 namespace PVTPackage
 {
 
@@ -61,11 +59,6 @@ bool BlackOilFlash::computeEquilibrium( BlackOilFlashMultiphaseSystemProperties 
     BlackOilDeadOilProperties tmp( 0.0, 0.0, 0.0 );
     sysProps.setOilModelProperties( tmp );
     sysProps.setGasModelProperties( tmp );
-
-    // fugacities
-    sysProps.setOilLnFugacity( { std::log( 1.0 ), std::log( 1.0 ), std::log( 1.0 ) } );
-    sysProps.setGasLnFugacity( { std::log( 1.0 ), std::log( 1.0 ), std::log( 1.0 ) } );
-    sysProps.setWaterLnFugacity( { std::log( 1.0 ), std::log( 1.0 ), std::log( 1.0 ) } );        
 
     // water
     auto const waterProperties = m_waterPhaseModel.computeProperties( pressure );
@@ -129,11 +122,6 @@ bool BlackOilFlash::computeEquilibrium( BlackOilFlashMultiphaseSystemProperties 
       sysProps.setOilMoleComposition( oilMoleComposition );
       auto const oilUnderSaturatedProperties = m_oilPhaseModel.computeUnderSaturatedProperties( pressure, oilMoleComposition, gasSurfaceMoleDensity, gasSurfaceMassDensity );
       sysProps.setOilModelProperties( oilUnderSaturatedProperties );
-
-      // LN FUGACITIES
-      sysProps.setOilLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
-      sysProps.setGasLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
-      sysProps.setWaterLnFugacity( { std::log( 1. ), std::log( 1. ), std::log( 1. ) } );
     }
 
     // Water


### PR DESCRIPTION
This PR implements some fixes that we have used to match an Intersect test case using the Black-Oil model. Specifically:
- Check to avoid division by zero if a phase is absent
- Replace PVTG implementation with PVDG implementation
- Remove fugacities to avoid division by zero
- Skip "flash" for pure water injection